### PR TITLE
Use npm's native pack and Add Github Action for publishing releases to NPMJS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish
+on: 
+  release:
+   types: [published]
+  push:
+    branches:
+      - 'lester/*'
+
+jobs:
+  publish-to-github-packages:
+    permissions:
+      packages: write
+      contents: read
+    uses: millicast/github-actions/.github/workflows/npm-publish.yml@main
+    with:
+      registry-url: 'https://registry.npmjs.org/'
+    secrets:
+      token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
    types: [published]
 
 jobs:
-  publish-to-github-packages:
+  publish-npmjs:
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Publish
 on: 
-  release:
-   types: [published]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   publish-npmjs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,6 @@ name: Publish
 on: 
   release:
    types: [published]
-  push:
-    branches:
-      - 'lester/*'
 
 jobs:
   publish-to-github-packages:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "swig": "swig -javascript -node -c++ src/video-codecs.i",
     "build": "node-gyp build --jobs=max",
     "install": "test -f build/Release/medooze-video-codecs.node || (node-gyp configure && node-gyp rebuild --jobs=max)",
-    "package": "tar cvzf build/medooze-video-codecs.tgz  `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-video-codecs/|\") || echo \" --transform=flags=r;s|^|medooze-video-codecs/|\"` media-server/src/* media-server/include/* media-server/ext/libdatachannels/src/* media-server/ext/crc32c/* lib/* package.json index.js  binding.gyp  README.md src",
     "dist": "node-gyp configure && node-gyp build --jobs=max && mkdir -p dist && tar cvzf dist/medooze-video-codecs-`node -e 'console.log(require(\"./package.json\").version)'`.tgz `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-video-codecs/|\") || echo \" --transform=flags=r;s|^|medooze-video-codecs/|\"` package.json index.js   README.md lib/* build/Release/medooze-video-codecs.node",
     "test": "tap tests/*.js --cov --no-check-coverage"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "swig": "swig -javascript -node -c++ src/video-codecs.i",
     "build": "node-gyp build --jobs=max",
     "install": "test -f build/Release/medooze-video-codecs.node || (node-gyp configure && node-gyp rebuild --jobs=max)",
+    "package": "tar cvzf build/medooze-video-codecs.tgz  `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-video-codecs/|\") || echo \" --transform=flags=r;s|^|medooze-video-codecs/|\"` media-server/src/* media-server/include/* media-server/ext/libdatachannels/src/* media-server/ext/crc32c/* lib/* package.json index.js  binding.gyp  README.md src",
     "dist": "node-gyp configure && node-gyp build --jobs=max && mkdir -p dist && tar cvzf dist/medooze-video-codecs-`node -e 'console.log(require(\"./package.json\").version)'`.tgz `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-video-codecs/|\") || echo \" --transform=flags=r;s|^|medooze-video-codecs/|\"` package.json index.js   README.md lib/* build/Release/medooze-video-codecs.node",
     "test": "tap tests/*.js --cov --no-check-coverage"
   },
@@ -31,7 +32,8 @@
     "media-server/src/*",
     "media-server/include/*",
     "media-server/ext/libdatachannels/src/*",
-    "media-server/ext/crc32c/* lib/*",
+    "media-server/ext/crc32c/*",
+    "lib/*",
     "package.json",
     "index.js",
     "binding.gyp",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "swig": "swig -javascript -node -c++ src/video-codecs.i",
     "build": "node-gyp build --jobs=max",
     "install": "test -f build/Release/medooze-video-codecs.node || (node-gyp configure && node-gyp rebuild --jobs=max)",
-    "package": "tar cvzf build/medooze-video-codecs.tgz  `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-video-codecs/|\") || echo \" --transform=flags=r;s|^|medooze-video-codecs/|\"` media-server/src/* media-server/include/* media-server/ext/libdatachannels/src/* media-server/ext/crc32c/* lib/* package.json index.js  binding.gyp  README.md src",
     "dist": "node-gyp configure && node-gyp build --jobs=max && mkdir -p dist && tar cvzf dist/medooze-video-codecs-`node -e 'console.log(require(\"./package.json\").version)'`.tgz `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-video-codecs/|\") || echo \" --transform=flags=r;s|^|medooze-video-codecs/|\"` package.json index.js   README.md lib/* build/Release/medooze-video-codecs.node",
     "test": "tap tests/*.js --cov --no-check-coverage"
   },
@@ -27,5 +26,16 @@
     "nan": "^2.18.0",
     "tap": "^16.3.2",
     "uuid": "^3.3.2"
-  }
+  },
+  "files": [
+    "media-server/src/*",
+    "media-server/include/*",
+    "media-server/ext/libdatachannels/src/*",
+    "media-server/ext/crc32c/* lib/*",
+    "package.json",
+    "index.js",
+    "binding.gyp",
+    "README.md",
+    "src"
+  ]
 }


### PR DESCRIPTION
Deprecate the package runscript in favor of the native `npm pack`. Diff between old and new tarball is only that npm will also include LICENSE and README.md's it finds:

![image](https://github.com/medooze/video-codecs-node/assets/145613755/1ad77d1a-6ffb-43c0-9e01-47b80f2be111)

An example run of the Github Publish action is here (I did not bump the package version in this PR since I did not want to publish anything, so it fails since the package version already exists): https://github.com/medooze/video-codecs-node/actions/runs/9025411908/job/24801088687