### PR TITLE
a few typos

### DIFF
--- a/lib/VideoDecoder.js
+++ b/lib/VideoDecoder.js
@@ -54,7 +54,7 @@ class VideoDecoder extends Emitter
 		const stats = this.decoder.GetStats();
 
 		//Ensure they are not too old
-		if (stats.timestamp + 1000 < new Date().time)
+		if (stats.timestamp + 1000 < new Date().getTime())
 			//Nothing
 			return null;
 			

--- a/lib/VideoEncoder.js
+++ b/lib/VideoEncoder.js
@@ -64,8 +64,8 @@ class VideoEncoder extends Emitter
 		const scaleResolutionToHeight = params.scaleResolutionToHeight ? parseInt(params.scaleResolutionToHeight) : 0;
 		const allowedDownScaling = scaleResolutionToHeight && params.hasOwnProperty("allowSameHeight")? (params.allowSameHeight ? 1 : 2) : 0;
 		//Get default for width and heights
-		const width  = parseInt(params.width)  ? parseInt(params.width)  : (scaleResolutionDownBy ? 640 : 0);
-		const height = parseInt(params.height) ? parseInt(params.height) : (scaleResolutionDownBy ? 480 : 0);
+		const width  = params.width  ? parseInt(params.width)  : (scaleResolutionDownBy ? 640 : 0);
+		const height = params.height ? parseInt(params.height) : (scaleResolutionDownBy ? 480 : 0);
 		//Set codec
 		if (!encoder.SetVideoCodec(codec,width,height,parseInt(params.fps),parseInt(params.bitrate),parseInt(params.intraPeriod || 0), properties))
 			//Error
@@ -105,7 +105,7 @@ class VideoEncoder extends Emitter
 		const stats = this.encoder.GetStats();
 
 		//Ensure they are not too old
-		if (stats.timestamp + 1000 < new Date().time)
+		if (stats.timestamp + 1000 < new Date().getTime())
 			//Nothing
 			return null;
 			
@@ -120,7 +120,7 @@ class VideoEncoder extends Emitter
 				avg		: stats.avgEncodingTime,
 			},
 			capturingTime : {
-				maxa		: stats.maxCapturingTime,
+				max		: stats.maxCapturingTime,
 				avg		: stats.avgCapturingTime,
 			}
 		};


### PR DESCRIPTION
a handful of lil typos found while typechecking the codebase. despite them being obvious typos, I did not apply these changes to master because the fix might break things:

- `new Date().time` doesn't exist, so the check was always failing and returning stats even if they are stale. fixing the typo makes it return `null` when stats are stale, as intended.

- an attribute was named `maxa` instead of `max`. fixing it could break code relying on the typo.